### PR TITLE
Plugins

### DIFF
--- a/apps/accounts/index.js
+++ b/apps/accounts/index.js
@@ -1,17 +1,20 @@
-module.exports = function (db, options) {
+module.exports = function (options) {
   options = options || {}
-  var model = require('./model')(db, options)
-  var handler = require('./handler')(model, options)
-  var routes = require('./routes')(handler, options)
 
-  return {
-    name: 'accounts',
-    model: model,
-    schema: model.schema,
-    handler: handler,
-    routes: routes,
-    serve: function (req, res) {
-      return routes.match(req, res)
+  return function (server) {
+    var model = require('./model')(server.db, options)
+    var handler = require('./handler')(model, options)
+    var routes = require('./routes')(handler, options)
+
+    return {
+      name: 'accounts',
+      model: model,
+      schema: model.schema,
+      handler: handler,
+      routes: routes,
+      serve: function (req, res) {
+        return routes.match(req, res)
+      }
     }
   }
 }

--- a/apps/activity/index.js
+++ b/apps/activity/index.js
@@ -1,17 +1,20 @@
-module.exports = function (db, options) {
+module.exports = function (options) {
   options = options || {}
-  var model = require('./model')(db, options)
-  var handler = require('./handler')(model, options)
-  var routes = require('./routes')(handler, options)
 
-  return {
-    name: 'activity',
-    schema: model.schema,
-    model: model,
-    handler: handler,
-    routes: routes,
-    serve: function (req, res) {
-      return routes.match(req, res)
+  return function (server) {
+    var model = require('./model')(server.db, options)
+    var handler = require('./handler')(model, options)
+    var routes = require('./routes')(handler, options)
+
+    return {
+      name: 'activity',
+      schema: model.schema,
+      model: model,
+      handler: handler,
+      routes: routes,
+      serve: function (req, res) {
+        return routes.match(req, res)
+      }
     }
   }
 }

--- a/apps/discuss/comments/index.js
+++ b/apps/discuss/comments/index.js
@@ -1,17 +1,20 @@
-module.exports = function (db, options) {
+module.exports = function (options) {
   options = options || {}
-  var model = require('./model')(db, options)
-  var handler = require('./handler')(model, options)
-  var routes = require('./routes')(handler, options)
 
-  return {
-    name: 'comments',
-    schema: model.schema,
-    model: model,
-    handler: handler,
-    routes: routes,
-    serve: function (req, res) {
-      return routes.match(req, res)
+  return function (server) {
+    var model = require('./model')(server.db, options)
+    var handler = require('./handler')(model, options)
+    var routes = require('./routes')(handler, options)
+
+    return {
+      name: 'comments',
+      schema: model.schema,
+      model: model,
+      handler: handler,
+      routes: routes,
+      serve: function (req, res) {
+        return routes.match(req, res)
+      }
     }
   }
 }

--- a/apps/discuss/posts/index.js
+++ b/apps/discuss/posts/index.js
@@ -1,17 +1,20 @@
-module.exports = function (db, options) {
+module.exports = function (options) {
   options = options || {}
-  var model = require('./model')(db, options)
-  var handler = require('./handler')(model, options)
-  var routes = require('./routes')(handler, options)
 
-  return {
-    name: 'posts',
-    model: model,
-    schema: model.schema,
-    handler: handler,
-    routes: routes,
-    serve: function (req, res) {
-      return routes.match(req, res)
+  return function (server) {
+    var model = require('./model')(server.db, options)
+    var handler = require('./handler')(model, options)
+    var routes = require('./routes')(handler, options)
+
+    return {
+      name: 'posts',
+      model: model,
+      schema: model.schema,
+      handler: handler,
+      routes: routes,
+      serve: function (req, res) {
+        return routes.match(req, res)
+      }
     }
   }
 }

--- a/apps/profiles/index.js
+++ b/apps/profiles/index.js
@@ -1,17 +1,20 @@
-module.exports = function (db, options) {
+module.exports = function (options) {
   options = options || {}
-  var model = require('./model')(db, options)
-  var handler = require('./handler')(model, options)
-  var routes = require('./routes')(handler, options)
 
-  return {
-    name: 'profiles',
-    model: model,
-    schema: model.schema,
-    handler: handler,
-    routes: routes,
-    serve: function (req, res) {
-      return routes.match(req, res)
+  return function (server) {
+    var model = require('./model')(server.db, options)
+    var handler = require('./handler')(model, options)
+    var routes = require('./routes')(handler, options)
+
+    return {
+      name: 'profiles',
+      model: model,
+      schema: model.schema,
+      handler: handler,
+      routes: routes,
+      serve: function (req, res) {
+        return routes.match(req, res)
+      }
     }
   }
 }

--- a/apps/schema/index.js
+++ b/apps/schema/index.js
@@ -1,14 +1,17 @@
-module.exports = function (server, options) {
+module.exports = function (options) {
   options = options || {}
-  var handler = require('./handler')(server, options)
-  var routes = require('./routes')(handler, options)
 
-  return {
-    name: 'schema',
-    handler: handler,
-    routes: routes,
-    serve: function (req, res) {
-      return routes.match(req, res)
+  return function (server) {
+    var handler = require('./handler')(server, options)
+    var routes = require('./routes')(handler, options)
+
+    return {
+      name: 'schema',
+      handler: handler,
+      routes: routes,
+      serve: function (req, res) {
+        return routes.match(req, res)
+      }
     }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ function Township (db, options) {
   })
 
   this.apps = {}
-  
+
   if (options.apps) {
     for (app in options.apps) {
       this.add(options.apps[app])
@@ -44,7 +44,7 @@ function Township (db, options) {
 }
 
 Township.prototype.add = function (app) {
-  this.apps[app.name] = app
+  this.apps[app.name] = app(this)
 }
 
 Township.prototype.remove = function (name) {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "slug": "^0.8.0",
     "smokestack": "^3.2.2",
     "sqldown": "^1.2.0",
+    "st": "^0.5.4",
     "stream-collector": "^1.0.1",
     "subcommand": "^2.0.1",
     "subleveldown": "^1.0.6",


### PR DESCRIPTION
This PR changes the api slightly around apps.  Apps should return a function that returns an object that adheres to the App spec.  This allows app authors easy access to the server instance.

An example:

```js
module.exports = function (options) {
  options = options || {}

  return function (server) {
    var model = require('./model')(server, options)
    var handler = require('./handler')(model, options, server)
    var routes = require('./routes')(handler, options)

    return {
      name: 'media',
      model: model,
      schema: model.schema,
      handler: handler,
      routes: routes,
      serve: function (req, res) {
        return routes.match(req, res)
      }
    }
  }
}
```