### PR TITLE
init app before accessing app.name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,8 @@ function Township (db, options) {
 }
 
 Township.prototype.add = function (app) {
-  this.apps[app.name] = app(this)
+  app = app(this)
+  this.apps[app.name] = app
 }
 
 Township.prototype.remove = function (name) {


### PR DESCRIPTION
fixes a bug I created where apps weren't being properly mounted