### PR TITLE
remove unused dependency `marked`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@ var mkdirp = require('mkdirp')
 var parse = require('body/any')
 var Router = require('match-routes')
 var response = require('response')
-var marked = require('marked')
 var filter = require('filter-object')
 var st = require('st')
 


### PR DESCRIPTION
It was removed from `package.json` but not this file so township is erroring out on startup.