### PR TITLE
add `upload` method for uploading FormData File objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "slug": "^0.8.0",
     "smokestack": "^3.2.2",
     "sqldown": "^1.2.0",
+    "st": "^0.5.4",
     "stream-collector": "^1.0.1",
     "subcommand": "^2.0.1",
     "subleveldown": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "accountdown-model": "^1.0.0",
     "body": "^4.5.0",
     "clone": "^1.0.2",
+    "component-upload": "^0.3.0",
     "cookie-auth": "^2.4.1",
     "corsify": "^2.0.0",
     "cuid": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "accountdown-model": "^1.0.0",
     "body": "^4.5.0",
     "clone": "^1.0.2",
-    "component-upload": "^0.3.0",
     "cookie-auth": "^2.4.1",
     "corsify": "^2.0.0",
     "cuid": "^1.2.4",


### PR DESCRIPTION
I added this method as a convenience for uploading File objects for now because it was a lot easier than refactoring the `api-client#request` method to accept FormData.  I also thought the module `request` was https://github.com/request/request and I wasn't able to get it to work properly.  I didn't realize it was `xhr` until I was writing this PR.